### PR TITLE
🐛Fix name collision with `store`

### DIFF
--- a/src/AppStore.js
+++ b/src/AppStore.js
@@ -1,5 +1,4 @@
 import { createConnectedStore } from 'undux'
 
 export default createConnectedStore({
-  
 })

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import 'index.css';
 import App from 'scenes/App/App';
 import * as serviceWorker from 'serviceWorker';
-import Store from 'store';
+import Store from 'AppStore';
 
 ReactDOM.render(<Store.Container><App /></Store.Container>, document.getElementById('root'));
 


### PR DESCRIPTION
renames store to AppStore to avoid phantom namespace issues