### PR TITLE
Changed url from localhost for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Configuration
+
+- Ensure that your /etc/hosts includes the following line: `127.0.0.1 local.virtru.com`
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "virtru-tdf3-js": "git@github.com:virtru/virtru-tdf3-js.git#semver:^0"
   },
   "scripts": {
-    "start": "HTTPS=true PORT=443 react-scripts start",
+    "start": "HTTPS=true PORT=443 HOST='local.virtru.com' react-scripts start",
     "build": "react-scripts build",
     "precommit": "pretty-quick --staged",
     "postcommit": "git update-index -g",


### PR DESCRIPTION
Login doesnt work cause login request triggers from `localhost` and gets blocked as cross origin. 
`npm start` command was updated.
https://facebook.github.io/create-react-app/docs/advanced-configuration. 

local.virtru.com was set as host as its added to accounts whitelist. 

Readme was updated