### PR TITLE
Add Google Tag Manager to public Protect and Track Demo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,21 +8,33 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>DSAT: TDF Sharing</title>
     <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-KHN6V76');</script>
-<!-- End Google Tag Manager →
-
+    <script>
+      (function(w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-KHN6V76');
+    </script>
+    <!-- End Google Tag Manager -->
   </head>
 
   <body>
     <noscript>This is a JavaScript application; please enable it to access this app.</noscript>
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KHN6V76"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-KHN6V76"
+        height="0"
+        width="0"
+        style="display:none;visibility:hidden"
+      ></iframe
+    ></noscript>
+    <!-- End Google Tag Manager (noscript) -->
 
     <div id="root"></div>
   </body>


### PR DESCRIPTION
This commit adds a Google Tag Manager container that contains Google Analytics and Amplitude event tracking calls, so we can track demo usage. Please reach out to Rob or Karthik if any confirmation is needed on this.