### PR TITLE
⬆️ Update SDK to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sdk-share",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14516,9 +14516,9 @@
       }
     },
     "virtru-sdk": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/virtru-sdk/-/virtru-sdk-1.6.15.tgz",
-      "integrity": "sha512-2KswtNhzuGfXbjxZiWu40Tjewwd0GScg4M1pu5mPH0RzIMozIJVTHHlV0Gz+g5462mUtID9QvrAarEDW/zGxZw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/virtru-sdk/-/virtru-sdk-2.0.0.tgz",
+      "integrity": "sha512-dEM3CNkiAO3TtSigri7sDMbjrBMdSezVUKoKHwqWFF0wjUuI541jB9sOEg1kmTrrnOvh0ogo0ooqAAKRiTLa/w==",
       "requires": {
         "formidable": "^1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.3.1",
     "redux-zero": "^5.0.4",
-    "virtru-sdk": "beta"
+    "virtru-sdk": "^2.0.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Ideally we would have a matrix of releases to allow pre-release versions of the SDK (and old versions) to be available to test at the same time.