### PR TITLE
🚧 PLAT-261 Select virtru-sdk version at runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14515,10 +14515,18 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "virtru-sdk": {
-      "version": "2.0.0",
+    "virtru-sdk-current": {
+      "version": "npm:virtru-sdk@2.0.0",
       "resolved": "https://registry.npmjs.org/virtru-sdk/-/virtru-sdk-2.0.0.tgz",
       "integrity": "sha512-dEM3CNkiAO3TtSigri7sDMbjrBMdSezVUKoKHwqWFF0wjUuI541jB9sOEg1kmTrrnOvh0ogo0ooqAAKRiTLa/w==",
+      "requires": {
+        "formidable": "^1.2.1"
+      }
+    },
+    "virtru-sdk-lts": {
+      "version": "npm:virtru-sdk@1.6.11",
+      "resolved": "https://registry.npmjs.org/virtru-sdk/-/virtru-sdk-1.6.11.tgz",
+      "integrity": "sha512-wfR7wukNCGG4gkGWyNbaFsgw4BlskMrNDbqRCqTcvXyhSKgoGcwUMA8oY2ZsjJQIA4LiZrepH4RQhcesXAm6jw==",
       "requires": {
         "formidable": "^1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.3.1",
     "redux-zero": "^5.0.4",
-    "virtru-sdk": "^2.0.0"
+    "virtru-sdk-current": "npm:virtru-sdk@^2.0.0",
+    "virtru-sdk-lts": "npm:virtru-sdk@^1.6.3"
   },
   "license": "MIT",
   "repository": {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -24,7 +24,7 @@ import React from 'react';
 
 import { ReactComponent as LogoText } from 'assets/logo-text.svg';
 
-import Virtru from 'virtru-sdk';
+import Virtru from 'utils/sdk';
 import './Header.css';
 import GithubLogo from './github-logo.png';
 import { ReactComponent as GithubIcon } from './github-icon.svg';

--- a/src/scenes/App/App.js
+++ b/src/scenes/App/App.js
@@ -25,7 +25,7 @@ import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { connect } from 'redux-zero/react';
 import ENCRYPT_STATES from 'constants/encryptStates';
 import { base64ToArrayBuffer } from 'utils/buffer';
-import Virtru from 'virtru-sdk';
+import Virtru from 'utils/sdk';
 import uuid from 'uuid';
 
 import './App.css';

--- a/src/scenes/Document/Document.js
+++ b/src/scenes/Document/Document.js
@@ -24,7 +24,7 @@ import React, { useState, useEffect } from 'react';
 import { connect } from 'redux-zero/react/index';
 
 import Sidebar from '../Sidebar/Sidebar';
-import Virtru from 'virtru-sdk';
+import Virtru from 'utils/sdk';
 import uuid from 'uuid';
 
 import defaultConfig from 'utils/config';

--- a/src/scenes/Document/Document.test.js
+++ b/src/scenes/Document/Document.test.js
@@ -24,7 +24,7 @@ import React from 'react';
 import { cleanup, render, wait, fireEvent, getByTestId, act } from '@testing-library/react';
 import Document from './Document';
 import ENCRYPT_STATES from 'constants/encryptStates';
-import Virtru from 'virtru-sdk';
+import Virtru from 'utils/sdk';
 
 afterEach(cleanup);
 

--- a/src/scenes/Document/scenes/Policy/components/Access/Access.test.js
+++ b/src/scenes/Document/scenes/Policy/components/Access/Access.test.js
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 import React from 'react';
-import Virtru from 'virtru-sdk';
+import Virtru from 'utils/sdk';
 import { generatePolicyChanger } from '../../services/policyChanger';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 

--- a/src/scenes/Document/scenes/Policy/components/Expiration/Expiration.test.js
+++ b/src/scenes/Document/scenes/Policy/components/Expiration/Expiration.test.js
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 import React from 'react';
-import Virtru from 'virtru-sdk';
+import Virtru from 'utils/sdk';
 import { generatePolicyChanger } from '../../services/policyChanger';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 

--- a/src/store.js
+++ b/src/store.js
@@ -21,13 +21,14 @@
 // SOFTWARE.
 
 import createStore from 'redux-zero';
-import Virtru from 'virtru-sdk';
+import Virtru from 'utils/sdk';
 import moment from 'moment';
 
 import defaultConfig from 'utils/config';
 import { SHARE_PROVIDERS, SHARE_STATE } from 'constants/sharing';
 import checkIsMobile from 'utils/checkIsMobile';
 import checkIsSupportedBrowser from 'utils/checkIsSupportedBrowser';
+import getQueryParam from 'utils/getQueryParam';
 
 const auths = JSON.parse(localStorage.getItem('virtru-client-auth')) || null;
 const activeAuth = auths && Object.values(auths)[0];
@@ -130,13 +131,3 @@ export default createStore({
   // Any current alerts that should be displayed atop the app
   alert: false,
 });
-
-function getQueryParam(name, url) {
-  if (!url) url = window.location.href;
-  name = name.replace(/[\[\]]/g, '\\$&'); // eslint-disable-line no-useless-escape
-  var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
-    results = regex.exec(url);
-  if (!results) return null;
-  if (!results[2]) return '';
-  return decodeURIComponent(results[2].replace(/\+/g, ' '));
-}

--- a/src/utils/download.js
+++ b/src/utils/download.js
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Virtru from 'virtru-sdk';
+import Virtru from 'utils/sdk';
 import logAction from 'utils/virtruActionLogger';
 
 function click(node) {

--- a/src/utils/getQueryParam.js
+++ b/src/utils/getQueryParam.js
@@ -1,12 +1,17 @@
 export default (name, url) => {
   url = url || window.location.href;
   if (URL) {
-    return new URL(window.location.href).searchParams.get(name);
+    return new URL(url).searchParams.get(name);
   }
   name = name.replace(/[\[\]]/g, '\\$&'); // eslint-disable-line no-useless-escape
-  var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
-    results = regex.exec(url);
-  if (!results) return null;
-  if (!results[2]) return '';
-  return decodeURIComponent(results[2].replace(/\+/g, ' '));
+  const regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)');
+  const results = regex.exec(url);
+  if (!results) {
+    return null;
+  }
+  const value = results[2];
+  if (!value) {
+    return '';
+  }
+  return decodeURIComponent(value.replace(/\+/g, ' '));
 };

--- a/src/utils/getQueryParam.js
+++ b/src/utils/getQueryParam.js
@@ -1,0 +1,12 @@
+export default (name, url) => {
+  url = url || window.location.href;
+  if (URL) {
+    return new URL(window.location.href).searchParams.get(name);
+  }
+  name = name.replace(/[\[\]]/g, '\\$&'); // eslint-disable-line no-useless-escape
+  var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
+    results = regex.exec(url);
+  if (!results) return null;
+  if (!results[2]) return '';
+  return decodeURIComponent(results[2].replace(/\+/g, ' '));
+};

--- a/src/utils/policy.js
+++ b/src/utils/policy.js
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Virtru from 'virtru-sdk';
+import Virtru from 'utils/sdk';
 
 export const getPolicy = async ({ encrypted, virtruClient }) => {
   const decryptParams = new Virtru.DecryptParamsBuilder()

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -1,0 +1,15 @@
+import getQueryParam from 'utils/getQueryParam';
+
+// If in prod, only use current SDK.
+// Otherwise, allow selecting sdk by `zver` parameter.
+const ver = getQueryParam('zver');
+const sdk =
+  process.env.REACT_APP_VIRTRU_ENV === 'production'
+    ? console.log('SDK Selector: PRODUCTION') || require('virtru-sdk-current')
+    : ver === 'lts'
+    ? console.log('SDK Selector: LTS') || require('virtru-sdk-lts')
+    : console.log('SDK Selector: CURRENT') || require('virtru-sdk-current');
+
+export default {
+  ...sdk,
+};

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -2,13 +2,17 @@ import getQueryParam from 'utils/getQueryParam';
 
 // If in prod, only use current SDK.
 // Otherwise, allow selecting sdk by `zver` parameter.
-const ver = getQueryParam('zver');
+function sdkByParam() {
+  const ver = getQueryParam('zver');
+  return ver === 'lts'
+    ? console.log('SDK Selector: LTS') || require('virtru-sdk-lts')
+    : console.log('SDK Selector: CURRENT') || require('virtru-sdk-current');
+}
+
 const sdk =
   process.env.REACT_APP_VIRTRU_ENV === 'production'
     ? console.log('SDK Selector: PRODUCTION') || require('virtru-sdk-current')
-    : ver === 'lts'
-    ? console.log('SDK Selector: LTS') || require('virtru-sdk-lts')
-    : console.log('SDK Selector: CURRENT') || require('virtru-sdk-current');
+    : sdkByParam();
 
 export default {
   ...sdk,


### PR DESCRIPTION
To test, append `?zver=lts` to the URI, e.g. 

    https://demos.developer.virtru.com/protect-develop/?zver=lts

This will load the 1.6.3 version of the sdk, instead of the previous one. Ideally we would then be able to test against both versions in the integrated tests.

PLAT-261 - this should address this issue, when combined with the fix in https://github.com/virtru/protect-and-track/pull/146