### PR TITLE
🚀 1.2.3: Backend targeting (PLAT-261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/virtru/protect-and-track/compare/master...HEAD)
 
+## [v1.2.3](https://github.com/virtru/protect-and-track/compare/v1.2.2...v1.2.3) - 2020-02-19
+
 - PLAT-261: _patch_
 
   - [146](https://github.com/virtru/protect-and-track/pull/146): Default target backend based on host:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protect-and-track",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protect-and-track",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "homepage": ".",
   "dependencies": {


### PR DESCRIPTION
Fixes PLAT-261, allowing backend targeting and sdk selection on non-prod demo.

[Demo](https://demos.developer.virtru.com/protect-develop/?zver=lts)

Doesn't work. I'll need to target the correct auth. @jrschumacher @aleonov-virtru any ideas how to get the correct backend targeted (and maybe build) of the auth widget?