### PR TITLE
✨PLAT-261 let's backends be forceable in non-prod

### DIFF
--- a/src/scenes/AuthSelect/AuthSelect.js
+++ b/src/scenes/AuthSelect/AuthSelect.js
@@ -22,12 +22,16 @@
 
 import React, { useEffect } from 'react';
 import './AuthSelect.css';
+import { authOptions } from 'utils/config';
 import Modal from '../../components/Modal/Modal';
 
 function AuthSelect({ onClose, login }) {
   useEffect(() => {
     console.log('Mounting auth UI...');
-    window.Virtru.AuthWidget('virtru-auth-widget-mount', { afterAuth: login });
+    window.Virtru.AuthWidget('virtru-auth-widget-mount', {
+      afterAuth: login,
+      authOptions,
+    });
   }, [login]);
 
   return (

--- a/src/scenes/Document/Document.js
+++ b/src/scenes/Document/Document.js
@@ -27,7 +27,7 @@ import Sidebar from '../Sidebar/Sidebar';
 import Virtru from 'utils/sdk';
 import uuid from 'uuid';
 
-import defaultConfig from 'utils/config';
+import { clientConfig } from 'utils/config';
 import logAction from 'utils/virtruActionLogger';
 import Alert from './components/Alert/Alert';
 import Drop from './components/Drop/Drop';
@@ -433,7 +433,7 @@ const actions = {
         if (!virtruClient) {
           logAction('createClientWithEmail');
           // Virtru: Create the virtru client
-          client = new Virtru.Client({ ...defaultConfig, email: userId || 'a@b.invalid' });
+          client = new Virtru.Client({ ...clientConfig, email: userId || 'a@b.invalid' });
         }
 
         // Virtru: Get the policy id from the decrypt params

--- a/src/store.js
+++ b/src/store.js
@@ -52,6 +52,7 @@ if (userId) {
   email = userId;
   localStorage.setItem('virtru-demo-email', userId);
   const pathname = window.location.pathname;
+  // Strip out auth widget specified virtruAuthWidgetEmail
   const search = window.location.search
     .replace(/([?&])virtruAuthWidgetEmail(=[^&#]+&?)/, '$1')
     .replace(/[?&]$/, '');

--- a/src/store.js
+++ b/src/store.js
@@ -24,7 +24,7 @@ import createStore from 'redux-zero';
 import Virtru from 'utils/sdk';
 import moment from 'moment';
 
-import defaultConfig from 'utils/config';
+import { clientConfig } from 'utils/config';
 import { SHARE_PROVIDERS, SHARE_STATE } from 'constants/sharing';
 import checkIsMobile from 'utils/checkIsMobile';
 import checkIsSupportedBrowser from 'utils/checkIsSupportedBrowser';
@@ -63,7 +63,7 @@ let isLoggedIn = email && Virtru.Auth.isLoggedIn({ email });
 let virtruClient = false;
 
 if (isLoggedIn) {
-  virtruClient = new Virtru.Client({ ...defaultConfig, email });
+  virtruClient = new Virtru.Client({ ...clientConfig, email });
   userId = email;
 } else {
   // remove the email from localstorage

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,3 +1,5 @@
+import getQueryParam from 'utils/getQueryParam';
+
 const develop01 = {
   authOptions: {
     accountsUrl: 'https://api-develop01.develop.virtru.com/accounts',
@@ -54,13 +56,32 @@ const production = {
   },
 };
 
+function backendByParam() {
+  const api = getQueryParam('zapi');
+  return api === 'develop' || api === 'develop01'
+    ? console.log('Backend forced: develop01') || develop01
+    : api === 'develop02'
+    ? console.log('Backend forced: develop02') || develop02
+    : api === 'staging'
+    ? console.log('Backend forced: staging') || staging
+    : console.log('Backend forced: production') || production;
+}
+
+function backendByEnv() {
+  return process.env.REACT_APP_VIRTRU_ENV === 'production'
+    ? console.log('Backend Selector: PRODUCTION') || production
+    : process.env.REACT_APP_VIRTRU_ENV === 'staging'
+    ? console.log('Backend Selector: PRODUCTION') || staging
+    : process.env.REACT_APP_VIRTRU_ENV === 'develop02'
+    ? console.log('Backend Selector: develop02') || develop02
+    : console.log('Backend Selector: develop') || develop01;
+}
+
+// If in prod, only use production backend.
+// Otherwise, allow selecting sdk by `zapi` parameter.
 const config =
   process.env.REACT_APP_VIRTRU_ENV === 'production'
-    ? production
-    : process.env.REACT_APP_VIRTRU_ENV === 'staging'
-    ? staging
-    : process.env.REACT_APP_VIRTRU_ENV === 'develop02'
-    ? develop02
-    : develop01;
+    ? backendByEnv()
+    : backendByParam() || backendByEnv();
 
 export const { authOptions, clientConfig } = config;

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,29 +1,57 @@
 const develop01 = {
-  kasEndpoint: 'https://api-develop01.develop.virtru.com/kas',
-  easEndpoint: 'https://api-develop01.develop.virtru.com/accounts',
-  acmEndpoint: 'https://api-develop01.develop.virtru.com/acm',
-  readerUrl: 'https://secure-develop01.develop.virtru.com/start?htmlProtocol=1',
+  authOptions: {
+    accountsUrl: 'https://api-develop01.develop.virtru.com/accounts',
+    acmUrl: 'https://api-develop01.develop.virtru.com/acm',
+    apiUrl: 'https://api-develop01.develop.virtru.com',
+  },
+  clientConfig: {
+    kasEndpoint: 'https://api-develop01.develop.virtru.com/kas',
+    easEndpoint: 'https://api-develop01.develop.virtru.com/accounts',
+    acmEndpoint: 'https://api-develop01.develop.virtru.com/acm',
+    readerUrl: 'https://secure-develop01.develop.virtru.com/start?htmlProtocol=1',
+  },
 };
 
 const develop02 = {
-  kasEndpoint: 'https://api-develop02.develop.virtru.com/kas',
-  easEndpoint: 'https://api-develop02.develop.virtru.com/accounts',
-  acmEndpoint: 'https://api-develop02.develop.virtru.com/acm',
-  readerUrl: 'https://secure-develop02.develop.virtru.com/start?htmlProtocol=1',
+  authOptions: {
+    accountsUrl: 'https://api-develop02.develop.virtru.com/accounts',
+    acmUrl: 'https://api-develop02.develop.virtru.com/acm',
+    apiUrl: 'https://api-develop02.develop.virtru.com',
+  },
+  clientConfig: {
+    kasEndpoint: 'https://api-develop02.develop.virtru.com/kas',
+    easEndpoint: 'https://api-develop02.develop.virtru.com/accounts',
+    acmEndpoint: 'https://api-develop02.develop.virtru.com/acm',
+    readerUrl: 'https://secure-develop02.develop.virtru.com/start?htmlProtocol=1',
+  },
 };
 
 const staging = {
-  kasEndpoint: 'https://api.staging.virtru.com/kas',
-  easEndpoint: 'https://api.staging.virtru.com/accounts',
-  acmEndpoint: 'https://api.staging.virtru.com/acm',
-  readerUrl: 'https://secure.staging.virtru.com/start?htmlProtocol=1',
+  authOptions: {
+    accountsUrl: 'https://api.staging.virtru.com/accounts',
+    acmUrl: 'https://api.staging.virtru.com/acm',
+    apiUrl: 'https://api.staging.virtru.com',
+  },
+  clientConfig: {
+    kasEndpoint: 'https://api.staging.virtru.com/kas',
+    easEndpoint: 'https://api.staging.virtru.com/accounts',
+    acmEndpoint: 'https://api.staging.virtru.com/acm',
+    readerUrl: 'https://secure.staging.virtru.com/start?htmlProtocol=1',
+  },
 };
 
 const production = {
-  kasEndpoint: 'https://api.virtru.com/kas',
-  easEndpoint: 'https://api.virtru.com/accounts',
-  acmEndpoint: 'https://api.virtru.com/acm',
-  readerUrl: 'https://secure.virtru.com/start?htmlProtocol=1',
+  authOptions: {
+    accountsUrl: 'https://api.virtru.com/accounts',
+    acmUrl: 'https://api.virtru.com/acm',
+    apiUrl: 'https://api.virtru.com',
+  },
+  clientConfig: {
+    kasEndpoint: 'https://api.virtru.com/kas',
+    easEndpoint: 'https://api.virtru.com/accounts',
+    acmEndpoint: 'https://api.virtru.com/acm',
+    readerUrl: 'https://secure.virtru.com/start?htmlProtocol=1',
+  },
 };
 
 const config =
@@ -35,4 +63,4 @@ const config =
     ? develop02
     : develop01;
 
-export default config;
+export const { authOptions, clientConfig } = config;

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -56,26 +56,40 @@ const production = {
   },
 };
 
-function backendByParam() {
-  const api = getQueryParam('zapi');
-  return api === 'develop' || api === 'develop01'
-    ? console.log('Backend forced: develop01') || develop01
-    : api === 'develop02'
-    ? console.log('Backend forced: develop02') || develop02
-    : api === 'staging'
-    ? console.log('Backend forced: staging') || staging
-    : console.log('Backend forced: production') || production;
-}
+const backendByParam = () => {
+  switch (getQueryParam('zapi')) {
+    case 'develop':
+    case 'develop01':
+      console.log('Backend forced: develop01');
+      return develop01;
+    case 'develop02':
+      console.log('Backend forced: develop02');
+      return develop02;
+    case 'staging':
+      console.log('Backend forced: staging');
+      return staging;
+    default:
+      console.log('Backend forced: production');
+      return production;
+  }
+};
 
-function backendByEnv() {
-  return process.env.REACT_APP_VIRTRU_ENV === 'production'
-    ? console.log('Backend Selector: PRODUCTION') || production
-    : process.env.REACT_APP_VIRTRU_ENV === 'staging'
-    ? console.log('Backend Selector: PRODUCTION') || staging
-    : process.env.REACT_APP_VIRTRU_ENV === 'develop02'
-    ? console.log('Backend Selector: develop02') || develop02
-    : console.log('Backend Selector: develop') || develop01;
-}
+const backendByEnv = () => {
+  switch (process.env.REACT_APP_VIRTRU_ENV) {
+    case 'production':
+      console.log('Backend Selector: production');
+      return production;
+    case 'develop02':
+      console.log('Backend Selector: develop02');
+      return develop02;
+    case 'staging':
+      console.log('Backend forced: staging');
+      return staging;
+    default:
+      console.log('Backend Selector: develop01');
+      return develop01;
+  }
+};
 
 // If in prod, only use production backend.
 // Otherwise, allow selecting sdk by `zapi` parameter.


### PR DESCRIPTION
* Fix auth widget to use per-tier configuration as well
* Add query param, `zapi`, which allows selecting backend. For example:

Backend\SDK|beta|lts
----------|----|---
develop01|https://demos.developer.virtru.com/protect-develop/?zapi=develop|https://demos.developer.virtru.com/protect-develop/?zapi=develop&zver=lts
develop02|https://demos.developer.virtru.com/protect-develop/?zapi=develop02|https://demos.developer.virtru.com/protect-develop/?zapi=develop02&zver=lts
staging|https://demos.developer.virtru.com/protect-develop/?zapi=staging|https://demos.developer.virtru.com/protect-develop/?zapi=staging&zver=lts
production|https://demos.developer.virtru.com/protect-develop/?zapi=production|https://demos.developer.virtru.com/protect-develop/?zapi=production&zver=lts