### PR TITLE
PLAT-261 update e2e scripts

### DIFF
--- a/.buildkite/scripts/e2e.sh
+++ b/.buildkite/scripts/e2e.sh
@@ -2,18 +2,11 @@
 
 set -eu
 
-# TEST_MARKER is the test suite that will be selected to run
-if [[ -n "${TEST_MARKER-}" ]]; then
-  echo "TEST_ENVIRONMENT_NAME: ${TEST_ENVIRONMENT_NAME}; TEST_MARKER: ${TEST_MARKER}"
-  dash_m="-m $TEST_MARKER"
-else
-  echo "TEST_ENVIRONMENT_NAME: ${TEST_ENVIRONMENT_NAME}"
-  dash_m=
-fi
+# TEST_MARKER is the test suite that will be selected to run, by default it is regression suite
+TEST_MARKER=${TEST_MARKER:-regression}
 
+# PYTEST_CONCURRENCY_NUM is the number of concurrent test runs
+PYTEST_CONCURRENCY_NUM=${PYTEST_CONCURRENCY_NUM:-"2"}
+echo "+++ TEST_ENVIRONMENT_NAME: $TEST_ENVIRONMENT_NAME; TEST_MARKER: $TEST_MARKER; PYTEST_CONCURRENCY_NUM: $PYTEST_CONCURRENCY_NUM"
 
-docker run --rm $(env | cut -f1 -d= | sed 's/^/-e /') \
-  virtru/automated-test:latest pytest \
-  -v -s -n2 protect-and-track-website \
-  $dash_m \
-  --cucumberjson=reports/cucumber_report.json --cucumber-json-expanded --html=reports/general_report.html --self-contained-html
+docker run --rm -it $(awk 'BEGIN{for(v in ENVIRON) print v}' | sed 's/^/-e /') -v "$PWD/e2e:/virtru/e2e" -v "$PWD/e2e/reports:/virtru/reports" -v "$PWD/.buildkite/scripts:/virtru/e2e/scripts"  virtru/automated-test:latest pytest -v -s -n$PYTEST_CONCURRENCY_NUM e2e -m $TEST_MARKER --cucumberjson=reports/cucumber_report.json --cucumber-json-expanded --html=reports/general_report.html --self-contained-html

--- a/e2e/tests/features/sdk_website.feature
+++ b/e2e/tests/features/sdk_website.feature
@@ -13,7 +13,7 @@ Feature: Protect and Track Demo Site
   Background:
     Given Project is protect-and-track-demo
 
-  @smoke
+  @regression
   Scenario Outline: Encrypt file in Protect and Track demo site
     Given an attachment file: <filename>
     When I start to run testrail <case_id>


### PR DESCRIPTION
* update e2e scripts
* There are 3 env vars:

# TEST_MARKER is the test suite that will be selected to run, by default it is regression suite
TEST_MARKER=${TEST_MARKER:-regression}

# PYTEST_CONCURRENCY_NUM is the number of concurrent test runs
PYTEST_CONCURRENCY_NUM=${PYTEST_CONCURRENCY_NUM:-"2"}

TODO:
TEST_ENVIRONMENT_NAME: how to determine?
