### PR TITLE
⬆️ virtru-sdk 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.2.5](https://github.com/virtru/protect-and-track/pull/)
+
+- []
+
+  - update SDK version to 2.3.1, smaller and no public key
+
 ## [v1.2.4](https://github.com/virtru/protect-and-track/pull/171)
 
 - [171]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v1.2.5](https://github.com/virtru/protect-and-track/pull/)
+## [v1.2.5](https://github.com/virtru/protect-and-track/pull/180)
 
-- []
+- [180]
 
   - update SDK version to 2.3.1, smaller and no public key
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5887,24 +5887,24 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protect-and-track",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11069,9 +11069,9 @@
       }
     },
     "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -17215,9 +17215,9 @@
       },
       "dependencies": {
         "@babel/runtime-corejs3": {
-          "version": "7.12.18",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.18.tgz",
-          "integrity": "sha512-ngR7yhNTjDxxe1VYmhqQqqXZWujGb6g0IoA4qeG6MxNGRnIw2Zo8ImY8HfaQ7l3T6GklWhdNfyhWk0C0iocdVA==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz",
+          "integrity": "sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==",
           "requires": {
             "core-js-pure": "^3.0.0",
             "regenerator-runtime": "^0.13.4"
@@ -17948,9 +17948,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.18",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
-          "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -17958,9 +17958,9 @@
       }
     },
     "virtru-sdk-current": {
-      "version": "npm:virtru-sdk@2.3.1-beta.2.1",
-      "resolved": "https://registry.npmjs.org/virtru-sdk/-/virtru-sdk-2.3.1-beta.2.1.tgz",
-      "integrity": "sha512-2dym9CTX7UgmezZnEyOFRtOIuHJQDiNuTI8W6bexibLddEYttg/7k/o5ZdksmrwvlWG35icBeWyA9sDc7bjvVA==",
+      "version": "npm:virtru-sdk@2.3.1",
+      "resolved": "https://registry.npmjs.org/virtru-sdk/-/virtru-sdk-2.3.1.tgz",
+      "integrity": "sha512-26t6WD9DlSdqRO/bjCMs8wmILTNTXmearoY+zoDeXF6hrBZQr1Nk4A8D1rAMZNnzzxXlkbhxhsCNLNT0SLzsDQ==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "formidable": "^1.2.2",
@@ -17969,9 +17969,9 @@
       },
       "dependencies": {
         "@babel/runtime-corejs3": {
-          "version": "7.12.18",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.18.tgz",
-          "integrity": "sha512-ngR7yhNTjDxxe1VYmhqQqqXZWujGb6g0IoA4qeG6MxNGRnIw2Zo8ImY8HfaQ7l3T6GklWhdNfyhWk0C0iocdVA==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz",
+          "integrity": "sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==",
           "requires": {
             "core-js-pure": "^3.0.0",
             "regenerator-runtime": "^0.13.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protect-and-track",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "homepage": ".",
   "dependencies": {
@@ -16,7 +16,7 @@
     "react-dom": "^16.13.0",
     "react-router-dom": "^5.1.2",
     "redux-zero": "^5.1.3",
-    "virtru-sdk-current": "npm:virtru-sdk@2.3.1-beta.2.1",
+    "virtru-sdk-current": "npm:virtru-sdk@2.3.1",
     "virtru-sdk-lts": "npm:virtru-sdk@^2.1.2"
   },
   "license": "MIT",


### PR DESCRIPTION
This transitively includes tdf3-js 4, which, among other things, no longer pre-emptively queries for a KAS public key