### PR TITLE
🎨 Add back .js extensions on imports

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -6,8 +6,8 @@ import * as Virtru from 'virtru-sdk';
 import './Header.css';
 import GithubLogo from './github-logo.png';
 import { ReactComponent as GithubIcon } from './github-icon.svg';
-import { Button } from '../Button/Button';
-import resetApp from '../../utils/resetApp';
+import { Button } from '../Button/Button.js';
+import resetApp from '../../utils/resetApp.js';
 
 const signOut = (email) => Promise.all(Virtru.Auth.logout(email && { email }), resetApp());
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'redux-zero/react';
-import { dispatchAuth } from './utils/dispatchAuth';
+import { dispatchAuth } from './utils/dispatchAuth.js';
 
 import './index.css';
-import App from './scenes/App/App';
-import * as serviceWorker from './serviceWorker';
-import store from './store';
+import App from './scenes/App/App.js';
+import * as serviceWorker from './serviceWorker.js';
+import store from './store.js';
 
 console.info(
   `AppInfo: ${process.env.REACT_APP_NAME}:${process.env.REACT_APP_VERSION}-${

--- a/src/scenes/App/App.js
+++ b/src/scenes/App/App.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { connect } from 'redux-zero/react';
-import { ENCRYPT_STATES } from '../../constants/encryptStates';
-import { base64ToArrayBuffer } from '../../utils/buffer';
+import { ENCRYPT_STATES } from '../../constants/encryptStates.js';
+import { base64ToArrayBuffer } from '../../utils/buffer.js';
 import * as Virtru from 'virtru-sdk';
 import { v4 as uuidv4 } from 'uuid';
 
 import './App.css';
-import Header from '../../components/Header/Header';
-import Document from '../../scenes/Document/Document';
+import Header from '../../components/Header/Header.js';
+import Document from '../../scenes/Document/Document.js';
 import localForage from 'localforage';
 
 const useEffect = React.useEffect;

--- a/src/scenes/App/App.test.js
+++ b/src/scenes/App/App.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import App from './App';
+import App from './App.js';
 import { fireEvent } from '@testing-library/react';
 
 const noop = () => {

--- a/src/scenes/AuthSelect/AuthSelect.js
+++ b/src/scenes/AuthSelect/AuthSelect.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import './AuthSelect.css';
-import { authOptions } from '../../utils/config';
-import { Modal } from '../../components/Modal/Modal';
+import { authOptions } from '../../utils/config.js';
+import { Modal } from '../../components/Modal/Modal.js';
 
 function AuthSelect({ onClose, login }) {
   useEffect(() => {

--- a/src/scenes/Document/Document.js
+++ b/src/scenes/Document/Document.js
@@ -1,28 +1,28 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'redux-zero/react/index';
 
-import Sidebar from '../Sidebar/Sidebar';
+import Sidebar from '../Sidebar/Sidebar.js';
 import * as Virtru from 'virtru-sdk';
 import { v4 as uuidv4 } from 'uuid';
 
-import logAction from '../../utils/virtruActionLogger';
-import Alert from './components/Alert/Alert';
-import Drop from './components/Drop/Drop';
-import Filename from './components/Filename/Filename';
-import Policy from './scenes/Policy/Policy';
-import { DownloadModal } from './scenes/DownloadModal/DownloadModal';
-import Share from '../Share/Share';
-import AuthSelect from '../AuthSelect/AuthSelect';
-import StayUp from '../StayUp/StayUp';
-import { generatePolicyChanger } from './scenes/Policy/services/policyChanger';
-import { ENCRYPT_STATES } from '../../constants/encryptStates';
+import logAction from '../../utils/virtruActionLogger.js';
+import Alert from './components/Alert/Alert.js';
+import Drop from './components/Drop/Drop.js';
+import Filename from './components/Filename/Filename.js';
+import Policy from './scenes/Policy/Policy.js';
+import { DownloadModal } from './scenes/DownloadModal/DownloadModal.js';
+import Share from '../Share/Share.js';
+import AuthSelect from '../AuthSelect/AuthSelect.js';
+import StayUp from '../StayUp/StayUp.js';
+import { generatePolicyChanger } from './scenes/Policy/services/policyChanger.js';
+import { ENCRYPT_STATES } from '../../constants/encryptStates.js';
 import localForage from 'localforage';
 
 import './Document.css';
 
 import { ReactComponent as FileIcon } from './assets/File-24.svg';
-import { Button } from '../../components/Button/Button';
-import { arrayBufferToBase64, fileToArrayBuffer } from '../../utils/buffer';
+import { Button } from '../../components/Button/Button.js';
+import { arrayBufferToBase64, fileToArrayBuffer } from '../../utils/buffer.js';
 
 let auditTimerId;
 

--- a/src/scenes/Document/Document.test.js
+++ b/src/scenes/Document/Document.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { cleanup, render, wait, fireEvent, getByTestId, act } from '@testing-library/react';
-import Document from './Document';
-import { ENCRYPT_STATES } from '../../constants/encryptStates';
+import Document from './Document.js';
+import { ENCRYPT_STATES } from '../../constants/encryptStates.js';
 import * as Virtru from 'virtru-sdk';
 
 afterEach(cleanup);

--- a/src/scenes/Document/components/Filename/Filename.js
+++ b/src/scenes/Document/components/Filename/Filename.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RevokeAll from '../RevokeAll/RevokeAll';
+import RevokeAll from '../RevokeAll/RevokeAll.js';
 import './Filename.css';
 
 function Filename({ userId, file, isTdf, isPolicyRevoked, revokePolicy }) {

--- a/src/scenes/Document/components/RevokeAll/RevokeAll.js
+++ b/src/scenes/Document/components/RevokeAll/RevokeAll.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
-import { Button } from '../../../../components/Button/Button';
-import { Modal } from '../../../../components/Modal/Modal';
+import { Button } from '../../../../components/Button/Button.js';
+import { Modal } from '../../../../components/Modal/Modal.js';
 
 import './RevokeAll.css';
 

--- a/src/scenes/Document/scenes/DownloadModal/DownloadModal.js
+++ b/src/scenes/Document/scenes/DownloadModal/DownloadModal.js
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 
-import { Modal } from '../../../../components/Modal/Modal';
-import { Button } from '../../../../components/Button/Button';
-import { downloadHtml, downloadTdf, downloadDecrypted } from '../../../../utils/download';
+import { Modal } from '../../../../components/Modal/Modal.js';
+import { Button } from '../../../../components/Button/Button.js';
+import { downloadHtml, downloadTdf, downloadDecrypted } from '../../../../utils/download.js';
 
 import './DownloadModal.css';
 import '../LoadingModal/LoadingModal.css';
 
-import { policyFlagCheck } from '../../../../utils/policy';
+import { policyFlagCheck } from '../../../../utils/policy.js';
 
 export const DownloadModal = ({ onClose, encrypted, virtruClient }) => {
   const [decrypting, setDecrypting] = useState(false);

--- a/src/scenes/Document/scenes/Policy/Policy.js
+++ b/src/scenes/Document/scenes/Policy/Policy.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import Access from './components/Access/Access';
-import Expiration from './components/Expiration/Expiration';
-import Watermarking from './components/Watermarking/Watermarking';
-import Resharing from './components/Resharing/Resharing';
-import { Button } from '../../../../components/Button/Button';
-import { ENCRYPT_STATES } from '../../../../constants/encryptStates';
+import Access from './components/Access/Access.js';
+import Expiration from './components/Expiration/Expiration.js';
+import Watermarking from './components/Watermarking/Watermarking.js';
+import Resharing from './components/Resharing/Resharing.js';
+import { Button } from '../../../../components/Button/Button.js';
+import { ENCRYPT_STATES } from '../../../../constants/encryptStates.js';
 import './Policy.css';
 
 function Policy({

--- a/src/scenes/Document/scenes/Policy/components/Access/Access.js
+++ b/src/scenes/Document/scenes/Policy/components/Access/Access.js
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 
-import { SectionHeader } from '../SectionHeader/SectionHeader';
+import { SectionHeader } from '../SectionHeader/SectionHeader.js';
 import { ReactComponent as AccessIcon } from './access.svg';
-import { NOPE } from '../../services/policyChanger';
+import { NOPE } from '../../services/policyChanger.js';
 import './Access.css';
-import { Button } from '../../../../../../components/Button/Button';
+import { Button } from '../../../../../../components/Button/Button.js';
 import { ReactComponent as InfoIcon } from './info-icon.svg';
 
 function Access({ encryptState, userId, policy, policyChange, isPolicyRevoked }) {

--- a/src/scenes/Document/scenes/Policy/components/Access/Access.test.js
+++ b/src/scenes/Document/scenes/Policy/components/Access/Access.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import * as Virtru from 'virtru-sdk';
-import { generatePolicyChanger } from '../../services/policyChanger';
+import { generatePolicyChanger } from '../../services/policyChanger.js';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 
-import { ENCRYPT_STATES } from '../../../../../../constants/encryptStates';
-import Access from './Access';
+import { ENCRYPT_STATES } from '../../../../../../constants/encryptStates.js';
+import Access from './Access.js';
 
 afterEach(cleanup);
 

--- a/src/scenes/Document/scenes/Policy/components/Expiration/Expiration.js
+++ b/src/scenes/Document/scenes/Policy/components/Expiration/Expiration.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import RadioButton from '../RadioButton/RadioButton';
-import { SectionHeader } from '../SectionHeader/SectionHeader';
-import Toggle from '../Toggle/Toggle';
+import RadioButton from '../RadioButton/RadioButton.js';
+import { SectionHeader } from '../SectionHeader/SectionHeader.js';
+import Toggle from '../Toggle/Toggle.js';
 import { ReactComponent as HourglassIcon } from './hourglass.svg';
 import classNames from 'classnames';
 import './Expiration.css';

--- a/src/scenes/Document/scenes/Policy/components/Expiration/Expiration.test.js
+++ b/src/scenes/Document/scenes/Policy/components/Expiration/Expiration.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import * as Virtru from 'virtru-sdk';
-import { generatePolicyChanger } from '../../services/policyChanger';
+import { generatePolicyChanger } from '../../services/policyChanger.js';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 
-import Expiration from './Expiration';
+import Expiration from './Expiration.js';
 
 afterEach(cleanup);
 

--- a/src/scenes/Document/scenes/Policy/components/Resharing/Resharing.js
+++ b/src/scenes/Document/scenes/Policy/components/Resharing/Resharing.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { SectionHeader } from '../SectionHeader/SectionHeader';
-import Toggle from '../Toggle/Toggle';
+import { SectionHeader } from '../SectionHeader/SectionHeader.js';
+import Toggle from '../Toggle/Toggle.js';
 import { ReactComponent as ForwardIcon } from './forward.svg';
 import classNames from 'classnames';
 import './Resharing.css';

--- a/src/scenes/Document/scenes/Policy/components/Watermarking/Watermarking.js
+++ b/src/scenes/Document/scenes/Policy/components/Watermarking/Watermarking.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { SectionHeader } from '../SectionHeader/SectionHeader';
-import Toggle from '../Toggle/Toggle';
+import { SectionHeader } from '../SectionHeader/SectionHeader.js';
+import Toggle from '../Toggle/Toggle.js';
 import { ReactComponent as WatermarkIcon } from './watermark.svg';
 import classNames from 'classnames';
 import './Watermarking.css';

--- a/src/scenes/Document/scenes/Policy/services/policyChanger.js
+++ b/src/scenes/Document/scenes/Policy/services/policyChanger.js
@@ -1,4 +1,4 @@
-import logAction, { builderLogger } from '../../../../../utils/virtruActionLogger';
+import logAction, { builderLogger } from '../../../../../utils/virtruActionLogger.js';
 
 export const NOPE = 'NOPE';
 

--- a/src/scenes/Share/Share.js
+++ b/src/scenes/Share/Share.js
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'redux-zero/react';
-import Loading from './components/Loading/Loading';
-import * as gsuite from './services/gsuite';
-import * as onedrive from './services/onedrive';
+import Loading from './components/Loading/Loading.js';
+import * as gsuite from './services/gsuite.js';
+import * as onedrive from './services/onedrive.js';
 import './Share.css';
-import { SHARE_STATE, SHARE_PROVIDERS, SHARE_TITLES } from '../../constants/sharing';
-import { Button } from '../../components/Button/Button';
-import { Modal } from '../../components/Modal/Modal';
+import { SHARE_STATE, SHARE_PROVIDERS, SHARE_TITLES } from '../../constants/sharing.js';
+import { Button } from '../../components/Button/Button.js';
+import { Modal } from '../../components/Modal/Modal.js';
 
 function Ico({ type }) {
   return <img alt="" src={`${type}.svg`} className="ShareSelect-ico" />;

--- a/src/scenes/Share/Share.test.js
+++ b/src/scenes/Share/Share.test.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import Share from './Share';
+import Share from './Share.js';
 import { SHARE_STATE, SHARE_PROVIDERS } from 'constants/sharing';
-import * as gsuite from './services/gsuite';
+import * as gsuite from './services/gsuite.js';
 
 jest.mock('./services/gsuite');
 

--- a/src/scenes/Share/services/gsuite.js
+++ b/src/scenes/Share/services/gsuite.js
@@ -1,7 +1,7 @@
 /* global gapi */
 
-import { loadGapi } from '../../../services/core/remoteLoad';
-import { awaitify } from '../../../services/core/awaitify';
+import { loadGapi } from '../../../services/core/remoteLoad.js';
+import { awaitify } from '../../../services/core/awaitify.js';
 
 // API connectors.
 // First, create a project at https://console.developers.google.com/

--- a/src/scenes/Share/services/onedrive.js
+++ b/src/scenes/Share/services/onedrive.js
@@ -1,4 +1,4 @@
-import { awaitify } from '../../../services/core/awaitify';
+import { awaitify } from '../../../services/core/awaitify.js';
 
 // NOTE(deployment)
 // To connect to OneDrive, you must have an MS Azure dev account and register

--- a/src/scenes/Sidebar/Sidebar.js
+++ b/src/scenes/Sidebar/Sidebar.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { connect } from 'redux-zero/react';
 import './Sidebar.css';
-import AuditLogger from './components/AuditLogger/AuditLogger';
+import AuditLogger from './components/AuditLogger/AuditLogger.js';
 
-import SdkLogger from './components/SdkLogger/SdkLogger';
+import SdkLogger from './components/SdkLogger/SdkLogger.js';
 
 const Sidebar = ({ tdfLog = [] }) => {
   return (

--- a/src/scenes/Sidebar/Sidebar.test.js
+++ b/src/scenes/Sidebar/Sidebar.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 
-import Sidebar from './Sidebar';
+import Sidebar from './Sidebar.js';
 import { render } from '@testing-library/react';
 
 describe('SdkLogger', () => {

--- a/src/scenes/Sidebar/components/AuditLogger/AuditLogger.js
+++ b/src/scenes/Sidebar/components/AuditLogger/AuditLogger.js
@@ -3,8 +3,8 @@ import { connect } from 'redux-zero/react';
 import { parse as parseCsvToJson } from 'json2csv';
 import './AuditLogger.css';
 import { Scrollbars } from 'rc-scrollbars';
-import { AuditEventItem } from './components/AuditEventItem/AuditEventItem';
-import { saver } from '../../../../utils/download';
+import { AuditEventItem } from './components/AuditEventItem/AuditEventItem.js';
+import { saver } from '../../../../utils/download.js';
 
 const { useEffect, useRef } = React;
 

--- a/src/scenes/Sidebar/components/AuditLogger/AuditLogger.test.js
+++ b/src/scenes/Sidebar/components/AuditLogger/AuditLogger.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, getByTestId, fireEvent } from '@testing-library/react';
-import AuditLogger from './AuditLogger';
+import AuditLogger from './AuditLogger.js';
 import moment from 'moment';
-import { AUDIT_EVENTS } from '../../../../constants/auditEvents';
-import * as Download from '../../../../utils/download';
+import { AUDIT_EVENTS } from '../../../../constants/auditEvents.js';
+import * as Download from '../../../../utils/download.js';
 
 describe('AuditLogger', () => {
   test('renders "Protect a file..." text if events array is empty', () => {

--- a/src/scenes/Sidebar/components/AuditLogger/components/AuditEventItem/AuditEventItem.js
+++ b/src/scenes/Sidebar/components/AuditLogger/components/AuditEventItem/AuditEventItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import './AuditEventItem.css';
-import { AUDIT_EVENTS } from '../../../../../../constants/auditEvents';
+import { AUDIT_EVENTS } from '../../../../../../constants/auditEvents.js';
 import { ReactComponent as Doc } from '../../../../../../assets/doc.svg';
 import { ReactComponent as Download } from '../../../../../../assets/download.svg';
 

--- a/src/scenes/Sidebar/components/SdkLogger/SdkLogger.js
+++ b/src/scenes/Sidebar/components/SdkLogger/SdkLogger.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import './SdkLogger.css';
 import { Scrollbars } from 'rc-scrollbars';
-import { SidebarItem } from './components/SidebarItem';
+import { SidebarItem } from './components/SidebarItem.js';
 
 const { useEffect, useRef } = React;
 

--- a/src/scenes/Sidebar/components/SdkLogger/SdkLogger.test.js
+++ b/src/scenes/Sidebar/components/SdkLogger/SdkLogger.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { render } from '@testing-library/react';
-import SdkLogger from './SdkLogger';
+import SdkLogger from './SdkLogger.js';
 
 describe('SdkLogger', () => {
   test('Should trigger window.PR.prettyPrint every time component renders', () => {

--- a/src/scenes/StayUp/StayUp.js
+++ b/src/scenes/StayUp/StayUp.js
@@ -1,6 +1,6 @@
 import React, { useLayoutEffect, useRef } from 'react';
 import './StayUp.css';
-import { Modal } from '../../components/Modal/Modal';
+import { Modal } from '../../components/Modal/Modal.js';
 
 function StayUp({ onClose, userId }) {
   const scriptWrapper = useRef();

--- a/src/store.js
+++ b/src/store.js
@@ -2,11 +2,11 @@ import createStore from 'redux-zero';
 import moment from 'moment';
 import * as Virtru from 'virtru-sdk';
 
-import { clientConfig } from './utils/config';
-import { SHARE_PROVIDERS, SHARE_STATE } from './constants/sharing';
-import { isMobile } from './utils/checkIsMobile';
-import { isSupportedBrowser } from './utils/checkIsSupportedBrowser';
-import { getQueryParam } from './utils/getQueryParam';
+import { clientConfig } from './utils/config.js';
+import { SHARE_PROVIDERS, SHARE_STATE } from './constants/sharing.js';
+import { isMobile } from './utils/checkIsMobile.js';
+import { isSupportedBrowser } from './utils/checkIsSupportedBrowser.js';
+import { getQueryParam } from './utils/getQueryParam.js';
 
 const auths = JSON.parse(localStorage.getItem('virtru-client-auth')) || null;
 const activeAuth = auths && Object.values(auths)[0];

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,4 +1,4 @@
-import { getQueryParam } from './getQueryParam';
+import { getQueryParam } from './getQueryParam.js';
 
 const develop01 = {
   authOptions: {

--- a/src/utils/virtruActionLogger.js
+++ b/src/utils/virtruActionLogger.js
@@ -1,6 +1,6 @@
 import { bindActions } from 'redux-zero/utils';
 import moment from 'moment';
-import store from '../store';
+import store from '../store.js';
 
 const boundActions = bindActions(
   {


### PR DESCRIPTION
- This is a potential recommended style in typescript, as described here: https://github.com/microsoft/TypeScript/issues/16577#issuecomment-754941937
- we don't currently have eslintrc set up. should I add it?
- This seems to be required to enable `node16` moduleResolution in tsconfig: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#esm-nodejs, which we will probably do at some point. 