### PR TITLE
🐛 Fix spurious `bye` parameter on logout uri

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -3,7 +3,7 @@ import { getQueryParam } from './getQueryParam';
 const oidcConfigShared = {
   clientId: process.env.REACT_APP_OIDC_CLIENT_ID,
   redirectUri: window.location.href.split(/[?#]/)[0],
-  postLogoutRedirectUri: window.location.href.split(/[?#]/)[0] + '?bye=1',
+  postLogoutRedirectUri: window.location.href.split(/[?#]/)[0],
   scope: 'openid profile email offline_access',
 };
 


### PR DESCRIPTION
this is causing redirects to fail, as it isn't registered with okta; it is also unused